### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tcnanalysis.py
+++ b/tcnanalysis.py
@@ -17,7 +17,7 @@ def JSONReturn(site):
     return: {'url_short': 'http://t.cn/xxx', 'url_long': site, 'type': 0}
     type: 链接的类型，0：普通网页(site page)、1：视频(video)、2：音乐(music)、3：活动(activity)、5、投票(vote)
     """
-    response = urllib.request.urlopen('http://api.t.sina.com.cn/short_url/shorten.json?source=3271760578&url_long=%s' % (site))
+    response = urllib.request.urlopen('http://api.t.sina.com.cn/short_url/shorten.json?source=3271760578&url_long={0!s}'.format((site)))
     html = response.read().decode('utf8')
     loads = json.loads(str(html))
     return loads[0]
@@ -27,7 +27,7 @@ def XMLReturn(site):
     xml analysis: XMLReturn(site='Website URL(format:http[s]://xxx)')
     return: {'url_short': 'http://t.cn/xxx', 'url_long': site}
     """
-    response = urllib.request.urlopen('http://api.t.sina.com.cn/short_url/shorten.xml?source=3271760578&url_long=%s' % (site))
+    response = urllib.request.urlopen('http://api.t.sina.com.cn/short_url/shorten.xml?source=3271760578&url_long={0!s}'.format((site)))
     html = response.read().decode('utf8')
     loads = et.fromstring(str(html))[0]
     return {"url_short": loads[0].text, "url_long": loads[1].text, "type": loads[2].text}
@@ -47,16 +47,16 @@ if __name__ == "__main__":
             break
     if 'x' == inputJorX:
         r_xml = XMLReturn(inputurl)
-        print(">>%s: \n> Short URL: %s" % (r_xml["url_long"], r_xml["url_short"]))
+        print(">>{0!s}: \n> Short URL: {1!s}".format(r_xml["url_long"], r_xml["url_short"]))
     if 'j' == inputJorX:
         r_json = JSONReturn(inputurl)
-        print(">>%s: \n> Short URL: %s" % (r_json["url_long"], r_json["url_short"]))
+        print(">>{0!s}: \n> Short URL: {1!s}".format(r_json["url_long"], r_json["url_short"]))
         while True:
             save_yn = input('>>Do you want to save it?[Y/n]').lower()
             if save_yn != 'y':
                 print("> Please enter 'y' or 'n'!")
             else:
                 print("> Saving...")
-                open('%s.json' % (re.search(r'(http://+)(.*)', inputurl).group(2)), 'w+').write(str(JSONReturn(inputurl)))
+                open('{0!s}.json'.format((re.search(r'(http://+)(.*)', inputurl).group(2))), 'w+').write(str(JSONReturn(inputurl)))
                 print("> OK")
                 break


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SmallFatCYW:tcn-analysis-python?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SmallFatCYW:tcn-analysis-python?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
